### PR TITLE
libndp: allow sending of NAs and Unsolicited NAs

### DIFF
--- a/include/ndp.h
+++ b/include/ndp.h
@@ -78,6 +78,8 @@ uint32_t ndp_msg_ifindex(struct ndp_msg *msg);
 void ndp_msg_ifindex_set(struct ndp_msg *msg, uint32_t ifindex);
 int ndp_msg_send(struct ndp *ndp, struct ndp_msg *msg);
 
+void ndp_msgna_override_set(struct ndp_msgna *msgna);
+
 uint8_t ndp_msgra_curhoplimit(struct ndp_msgra *msgra);
 void ndp_msgra_curhoplimit_set(struct ndp_msgra *msgra, uint8_t curhoplimit);
 bool ndp_msgra_flag_managed(struct ndp_msgra *msgra);

--- a/libndp/libndp.c
+++ b/libndp/libndp.c
@@ -278,7 +278,7 @@ struct ndp_msgns {
 };
 
 struct ndp_msgna {
-	struct nd_neighbor_solicit *na; /* must be first */
+	struct nd_neighbor_advert *na; /* must be first */
 };
 
 struct ndp_msgr {
@@ -359,6 +359,7 @@ static struct ndp_msg_type_info ndp_msg_type_info_list[] =
 		.strabbr = "NA",
 		.raw_type = ND_NEIGHBOR_ADVERT,
 		.raw_struct_size = sizeof(struct nd_neighbor_advert),
+		.addrto_adjust = ndp_msg_addrto_adjust_all_nodes,
 	},
 	[NDP_MSG_R] = {
 		.strabbr = "R",

--- a/libndp/libndp.c
+++ b/libndp/libndp.c
@@ -719,6 +719,24 @@ int ndp_msg_send(struct ndp *ndp, struct ndp_msg *msg)
 
 
 /**
+ * SECTION: msgna getters/setters
+ * @short_description: Getters and setters for NA message
+ */
+
+/**
+ * ndp_msgna_override_set:
+ * @msgra: NA message structure
+ *
+ * Set NA override flag for Unsolicited NA.
+ **/
+NDP_EXPORT
+void ndp_msgna_override_set(struct ndp_msgna *msgna)
+{
+	msgna->na->nd_na_hdr.icmp6_data32[0] |= ND_NA_FLAG_OVERRIDE;
+}
+
+
+/**
  * SECTION: msgra getters/setters
  * @short_description: Getters and setters for RA message
  */

--- a/libndp/libndp.c
+++ b/libndp/libndp.c
@@ -285,15 +285,6 @@ struct ndp_msgr {
 	struct nd_redirect *r; /* must be first */
 };
 
-typedef union nd_msg {
-	struct ndp_msggeneric	generic;
-	struct ndp_msgrs	rs;
-	struct ndp_msgra	ra;
-	struct ndp_msgns	ns;
-	struct ndp_msgna	na;
-	struct ndp_msgr		r;
-} ND_MSG;
-
 struct ndp_msg {
 #define NDP_MSG_BUFLEN 1500
 	unsigned char			buf[NDP_MSG_BUFLEN];
@@ -303,7 +294,14 @@ struct ndp_msg {
 	struct icmp6_hdr *		icmp6_hdr;
 	unsigned char *			opts_start; /* pointer to buf at the
 						       place where opts start */
-	ND_MSG				nd_msg;
+	union {
+		struct ndp_msggeneric	generic;
+		struct ndp_msgrs	rs;
+		struct ndp_msgra	ra;
+		struct ndp_msgns	ns;
+		struct ndp_msgna	na;
+		struct ndp_msgr		r;
+	} nd_msg;
 };
 
 struct ndp_msg_type_info {
@@ -312,7 +310,6 @@ struct ndp_msg_type_info {
 	uint8_t raw_type;
 	size_t raw_struct_size;
 	void (*addrto_adjust)(struct in6_addr *addr);
-	void (*data_adjust)(ND_MSG *nd_msg);
 };
 
 static void ndp_msg_addrto_adjust_all_nodes(struct in6_addr *addr)
@@ -339,13 +336,6 @@ static void ndp_msg_addrto_adjust_all_routers(struct in6_addr *addr)
 	addr->s6_addr32[3] = htonl(0x2);
 }
 
-/* set override flag for Unsolicited NA */
-static void ndp_msg_data_adjust_unsol_na(ND_MSG *nd_msg)
-{
-	struct ndp_msgna *msgna = (struct ndp_msgna*) &nd_msg->na;
-	msgna->na->nd_na_hdr.icmp6_data32[0] = ND_NA_FLAG_OVERRIDE;
-}
-
 static struct ndp_msg_type_info ndp_msg_type_info_list[] =
 {
 	[NDP_MSG_RS] = {
@@ -370,7 +360,6 @@ static struct ndp_msg_type_info ndp_msg_type_info_list[] =
 		.raw_type = ND_NEIGHBOR_ADVERT,
 		.raw_struct_size = sizeof(struct nd_neighbor_advert),
 		.addrto_adjust = ndp_msg_addrto_adjust_all_nodes,
-		.data_adjust = ndp_msg_data_adjust_unsol_na,
 	},
 	[NDP_MSG_R] = {
 		.strabbr = "R",
@@ -724,8 +713,6 @@ int ndp_msg_send(struct ndp *ndp, struct ndp_msg *msg)
 
 	if (ndp_msg_type_info(msg_type)->addrto_adjust)
 		ndp_msg_type_info(msg_type)->addrto_adjust(&msg->addrto);
-	if (ndp_msg_type_info(msg_type)->data_adjust)
-		ndp_msg_type_info(msg_type)->data_adjust(&msg->nd_msg);
 	return mysendto6(ndp->sock, msg->buf, msg->len, 0,
 			 &msg->addrto, msg->ifindex);
 }

--- a/man/ndptool.8
+++ b/man/ndptool.8
@@ -41,6 +41,10 @@ Neighbor Advertisement.
 .B "\-i ifname, \-\-ifname ifname"
 Specified interface name.
 
+.TP
+.B "\-U, \-\-unsolicited"
+Send Unsolicited NA.
+
 .SH COMMAND
 .TP
 .B "monitor"


### PR DESCRIPTION
As per RFC2461, all Unsolicited Neighbour Advertisements must have
the Override flag set. This patch adds a function to modify the
data of any ND message, and modifies the appropriate field to set
the Override flag when sending NAs.

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>