### PR TITLE
ndptool.c: Fix musl build

### DIFF
--- a/utils/ndptool.c
+++ b/utils/ndptool.c
@@ -27,6 +27,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <errno.h>
+#include <sys/select.h>
 #include <ndp.h>
 
 enum verbosity_level {


### PR DESCRIPTION
Fixes a build issue with the musl C library
http://autobuild.buildroot.net/results/d42/d42bebe51bbec38f131840b6bbefdc162f0ad194/build-end.log