### PR TITLE
libndp: fix type of field "na" in "struct ndp_msgna"

### DIFF
--- a/libndp/libndp.c
+++ b/libndp/libndp.c
@@ -278,7 +278,7 @@ struct ndp_msgns {
 };
 
 struct ndp_msgna {
-	struct nd_neighbor_solicit *na; /* must be first */
+	struct nd_neighbor_advert *na; /* must be first */
 };
 
 struct ndp_msgr {


### PR DESCRIPTION
Otherwise, compilation fails since commit cb1ab5fc8b:

   libndp.c: In function ‘ndp_msgna_flag_router’:
   libndp.c:992:18: error: ‘struct nd_neighbor_solicit’ has no member named ‘nd_na_hdr’
     return msgna->na->nd_na_flags_reserved & ND_NA_FLAG_ROUTER;

Fixes: dfed476eee192e86c140298810bb598c927645e8
Signed-off-by: Thomas Haller <thaller@redhat.com>