### PR TITLE
Remove dependency from bash

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 autoreconf --force --install -I m4
 rm -Rf autom4te.cache;


### PR DESCRIPTION
Allow to build on systems without pulling in bash where isn't the default shell