### PR TITLE
[th/thread-safe] make libndp thread safe

### DIFF
--- a/libndp/libndp.c
+++ b/libndp/libndp.c
@@ -221,11 +221,9 @@ resend:
 	return 0;
 }
 
-static const char *str_in6_addr(struct in6_addr *addr)
+static const char *str_in6_addr(struct in6_addr *addr, char buf[static INET6_ADDRSTRLEN])
 {
-	static char buf[INET6_ADDRSTRLEN];
-
-	return inet_ntop(AF_INET6, addr, buf, sizeof(buf));
+	return inet_ntop(AF_INET6, addr, buf, INET6_ADDRSTRLEN);
 }
 
 
@@ -1820,6 +1818,7 @@ static int ndp_sock_recv(struct ndp *ndp)
 	enum ndp_msg_type msg_type;
 	size_t len;
 	int err;
+	char buf[INET6_ADDRSTRLEN];
 
 	msg = ndp_msg_alloc();
 	if (!msg)
@@ -1833,7 +1832,7 @@ static int ndp_sock_recv(struct ndp *ndp)
 		goto free_msg;
 	}
 	dbg(ndp, "rcvd from: %s, ifindex: %u, hoplimit: %d",
-		 str_in6_addr(&msg->addrto), msg->ifindex, msg->hoplimit);
+		 str_in6_addr(&msg->addrto, buf), msg->ifindex, msg->hoplimit);
 
 	if (msg->hoplimit != 255) {
 		warn(ndp, "ignoring packet with bad hop limit (%d)", msg->hoplimit);

--- a/libndp/libndp.c
+++ b/libndp/libndp.c
@@ -1613,7 +1613,7 @@ uint32_t ndp_msg_opt_mtu(struct ndp_msg *msg, int offset)
 NDP_EXPORT
 struct in6_addr *ndp_msg_opt_route_prefix(struct ndp_msg *msg, int offset)
 {
-	static struct in6_addr prefix;
+	static NDP_THREAD struct in6_addr prefix;
 	struct __nd_opt_route_info *ri =
 			ndp_msg_payload_opts_offset(msg, offset);
 
@@ -1719,7 +1719,7 @@ NDP_EXPORT
 struct in6_addr *ndp_msg_opt_rdnss_addr(struct ndp_msg *msg, int offset,
 					int addr_index)
 {
-	static struct in6_addr addr;
+	static NDP_THREAD struct in6_addr addr;
 	struct __nd_opt_rdnss *rdnss =
 			ndp_msg_payload_opts_offset(msg, offset);
 	size_t len = rdnss->nd_opt_rdnss_len << 3; /* convert to bytes */
@@ -1769,7 +1769,7 @@ char *ndp_msg_opt_dnssl_domain(struct ndp_msg *msg, int offset,
 			       int domain_index)
 {
 	int i;
-	static char buf[256];
+	static NDP_THREAD char buf[256];
 	struct __nd_opt_dnssl *dnssl =
 			ndp_msg_payload_opts_offset(msg, offset);
 	size_t len = dnssl->nd_opt_dnssl_len << 3; /* convert to bytes */

--- a/libndp/ndp_private.h
+++ b/libndp/ndp_private.h
@@ -27,6 +27,7 @@
 #include "list.h"
 
 #define NDP_EXPORT __attribute__ ((visibility("default")))
+#define NDP_THREAD __thread
 
 /**
  * SECTION: ndp

--- a/utils/ndptool.c
+++ b/utils/ndptool.c
@@ -278,7 +278,7 @@ static int msgrcv_handler_func(struct ndp *ndp, struct ndp_msg *msg, void *priv)
 			pr_out("\n");
 		}
 		ndp_msg_opt_for_each_offset(offset, msg, NDP_MSG_OPT_RDNSS) {
-			static struct in6_addr *addr;
+			struct in6_addr *addr;
 			int addr_index;
 
 			pr_out("  Recursive DNS Servers: ");


### PR DESCRIPTION
Also, drop static variables from ndptool. It seems not good style to me.